### PR TITLE
Update README_JOTA_SITE.md

### DIFF
--- a/docs/README_JOTA_SITE.md
+++ b/docs/README_JOTA_SITE.md
@@ -42,6 +42,7 @@ original: https://docs.dmoj.ca/#/site/installation?id=creating-the-database
     ```
 
 ## Installing prerequisites
+앞으로 진행할과정에서 8001, 9999 포트 번호를 사용합니다. 충돌이 나지 않게 주의해주세요.
 original: https://docs.dmoj.ca/#/site/installation?id=installing-prerequisites
 
 * jota 디렉토리 생성 및 이동


### PR DESCRIPTION
<아래 내용을 수정함>
- 만약에 사용자 이름을 입력해야 한다면 ubuntu로 입력해야함.

- 할당받은 외부 IP는 JCLOUD에서 따로 받은 floating ip을 의미함

- curl 명령어로 `local_settings.py` 파일 다운로드 (dmojsite가 activate되지 않아도 할 수 있는 과정)

- Installing prerequisites에 포트 번호에 대한 주의 사항 표시
